### PR TITLE
Feat domain and fix token in URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ an example compose file for a dev/test environment would look like:
         - VLAB_URL=https://localhost
         - AUTH_LDAP_URL=ldaps://my.real.dc.corp
         - AUTH_SEARCH_BASE=DC=root,DC=for,DC=search,DC=corp
-        - AUTH_BASE=my.real.dc.corp
+        - AUTH_DOMAIN=CORP
      auth-redis:
       image:
         redis:3.2-alpine

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-auth-service",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='0.0.1',
+      version='2018.08.02',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_auth_service' : ['app.ini']},

--- a/vlab_auth_service/lib/constants.py
+++ b/vlab_auth_service/lib/constants.py
@@ -24,7 +24,7 @@ DEFINED = OrderedDict([
             ('AUTH_REDIS_HOSTNAME', environ.get('AUTH_REDIS_HOSTNAME', 'auth-redis')),
             ('AUTH_REDIS_PORT', environ.get('AUTH_REDIS_PORT', '6379')),
             ('AUTH_LDAP_URL', environ.get('AUTH_LDAP_URL', 'ldaps://localhost')),
-            ('AUTH_BASE', environ.get('AUTH_BASE', 'localhost.local')),
+            ('AUTH_DOMAIN', environ.get('AUTH_DOMAIN', 'CORP')),
             ('FAILED_LOGIN_PAUSE', 0.2), # Slow down any brute force login attempt
             ('AUTH_SEARCH_BASE', environ.get('AUTH_SEARCH_BASE','DC=localhost,DC=local')),
             ('AUTH_TOKEN_ALGORITHM', environ.get('AUTH_TOKEN_ALGORITHM', 'HS256')),

--- a/vlab_auth_service/lib/views/token.py
+++ b/vlab_auth_service/lib/views/token.py
@@ -178,7 +178,7 @@ def _user_ok(ldap_conn, username, log=logger):
     :param log: A logging object
     :param log: logging.Logger
     """
-    search_filter = '(&(objectclass=User)(uid=%s))' % username
+    search_filter = '(&(objectclass=User)(sAMAccountName=%s))' % username
     ldap_conn.search(search_base=const.AUTH_SEARCH_BASE,
                      search_filter=search_filter,
                      attributes=['memberOf', 'userAccountControl'])
@@ -223,7 +223,7 @@ def _bind_ldap(username, password, log=logger):
     conn = None
     status = 200
     try:
-        full_username = "{0}@{1}".format(username, const.AUTH_BASE)
+        full_username = "{0}\{1}".format(const.AUTH_DOMAIN, username)
         server = ldap3.Server(const.AUTH_LDAP_URL)
         conn = ldap3.Connection(server, full_username, password, auto_bind=True)
     except LDAPBindError:

--- a/vlab_auth_service/lib/views/token.py
+++ b/vlab_auth_service/lib/views/token.py
@@ -24,15 +24,9 @@ class TokenView(BaseView):
     """API end point for obtaining an auth token"""
     route_base = '/api/1/auth/token'
     version = 1
-    GET_ARGS_SCHEMA = {"$schema": "http://json-schema.org/draft-04/schema#",
-    	               "type": "object",
-                       "properties": {
-                          "token" : {
-                          "type" : "string",
-                          "description" : "Check if the token has been deleted"
-                          }
-                       }
-                      }
+    GET_SCHEMA = {"$schema": "http://json-schema.org/draft-04/schema#",
+                  "description" : "Check if the token has been deleted"
+                 }
     DELETE_SCHEMA = {"$schema": "http://json-schema.org/draft-04/schema#",
     	             "type": "object",
                 	 "properties": {
@@ -63,13 +57,13 @@ class TokenView(BaseView):
                 	]
                 }
 
-    @describe(get_args=GET_ARGS_SCHEMA, delete=DELETE_SCHEMA, post=POST_SCHEMA)
+    @describe(get=GET_SCHEMA, delete=DELETE_SCHEMA, post=POST_SCHEMA)
     def get(self):
         """Check if a token has been deleted"""
         resp = {'user' : 'unknown'}
-        token = request.args.get('token', default=None)
+        token = request.headers.get('X-Auth', default=None)
         if token is None:
-            resp['error'] = "Must supply the token parameter"
+            resp['error'] = "Must supply the token via the 'X-Auth' HTTP header"
             return ujson.dumps(resp), 400
         try:
             redis_server = StrictRedis(host=const.AUTH_REDIS_HOSTNAME, port=const.AUTH_REDIS_PORT)


### PR DESCRIPTION
TIL that it's pretty common for a UPN to *not* follow the patter of `samAccountName`@`domin fqdn`.

To allow the vLab CLI client to default to the user's login, the Auth service needed to bind to LDAP via the `DOMAIN` \ `samAccountName` pattern.

While making changes, I figured I'd fix the security issue of putting the JWT in a GET request vis-a-vis a URL parameter. Now, it just uses the `X-Auth` header, which keeps it compliant with the HTTP rfc (because you can't send body content in a GET).