### PR TITLE
no more server error when sent control chars

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-auth-service",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2018.09.19',
+      version='2018.12.21',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_auth_service' : ['app.ini']},


### PR DESCRIPTION
If you enter a username or password using the number pad on a keyboard while `NUM LOCK` is off, `ldap3` raises `LDAPSASLPrepError`. Because the service didn't catch this, it generated a Server Error response.

This update fixes that, and the error message should help users figure out _"why can't I log in!?"_