### PR TITLE
Using a specific image for Redis to avoid downloading from DockerHub all the time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ test: uninstall install
 
 images: build
 	docker build -t willnx/vlab-auth-service .
+	docker build -f RedisDockerfile -t willnx/vlab-auth-db .
 
 up: clean
 	docker-compose up --abort-on-container-exit

--- a/RedisDockerfile
+++ b/RedisDockerfile
@@ -1,0 +1,2 @@
+FROM redis:3.2-alpine
+RUN apk update && apk upgrade

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.4'
+services:
+    auth-api:
+     ports:
+       - 5000:5000
+     sysctls:
+       - net.core.somaxconn=1024
+     image:
+       willnx/vlab-auth-service
+     command: ["python3", "app.py"]
+     volumes:
+       - ./vlab_auth_service:/usr/lib/python3.6/site-packages/vlab_auth_service
+       #- ./private.key:/etc/vlab/auth_server/private.key
+       #- ./public.key:/etc/vlab/auth_server/public.key
+     environment:
+       - AUTH_TOKEN_TIMEOUT=18000
+       - AUTH_LDAP_URL=ldaps://10.146.130.182
+       - AUTH_DONMAIN=CORP
+       - AUTH_SEARCH_BASE=DC=corp,DC=emc,DC=com
+       - VLAB_URL=https://localhost
+       #- AUTH_TOKEN_ALGORITHM=RS512
+     restart: unless-stopped
+    auth-redis:
+     image:
+       willnx/vlab-auth-db
+     sysctls:
+       - net.core.somaxconn=1024
+     restart: unless-stopped


### PR DESCRIPTION
Because  https://www.docker.com/increase-rate-limit 😒 