### PR TITLE
Update to PyJWT 2.0.0 returns string when creating a JWT.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 setup(name="vlab-auth-service",
       author="Nicholas Willhite,",
       author_email='willnx84@gmail.com',
-      version='2020.10.23',
+      version='2020.12.29',
       packages=find_packages(),
       include_package_data=True,
       package_files={'vlab_auth_service' : ['app.ini']},

--- a/vlab_auth_service/lib/generate_token.py
+++ b/vlab_auth_service/lib/generate_token.py
@@ -10,7 +10,7 @@ from vlab_auth_service.lib import const
 def generate_token(username, version, memberOf, issued_at_timestamp):
     """Creates the JSON Web Token
 
-    :Returns: Bytes
+    :Returns: String
 
     :param username: The name of person who the token identifies
     :type username: String
@@ -28,13 +28,13 @@ def generate_token(username, version, memberOf, issued_at_timestamp):
               'version' : version,
               'memberOf' : memberOf,
              }
-    return jwt.encode(claims, const.AUTH_TOKEN_SECRET, algorithm=const.AUTH_TOKEN_ALGORITHM).decode()
+    return jwt.encode(claims, const.AUTH_TOKEN_SECRET, algorithm=const.AUTH_TOKEN_ALGORITHM)
 
 
 def generate_v2_token(username, version, client_ip, issued_at_timestamp, email=''):
     """Creates the JSON Web Token with a new schema
 
-    :Returns: Bytes
+    :Returns: String
 
     :param username: The name of person who the token identifies
     :type username: String
@@ -56,4 +56,4 @@ def generate_v2_token(username, version, client_ip, issued_at_timestamp, email='
               'client_ip' : client_ip,
               'email' : email,
              }
-    return jwt.encode(claims, const.AUTH_TOKEN_SECRET, algorithm=const.AUTH_TOKEN_ALGORITHM).decode()
+    return jwt.encode(claims, const.AUTH_TOKEN_SECRET, algorithm=const.AUTH_TOKEN_ALGORITHM)


### PR DESCRIPTION
This change in the JWT library is noted in the release notes:
https://github.com/jpadilla/pyjwt/releases/tag/2.0.0

Thankfully, these methods were already converting the bytes to a string for the caller. So there's no risk of _upstream_ breaks from this change.